### PR TITLE
Add system prompt argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <!-- Edit README.md, not index.md -->
 
 # Aider is AI pair programming in your terminal
@@ -77,7 +76,7 @@ Pair program with AI.
 - [Add images to the chat](https://aider.chat/docs/usage/images-urls.html) (GPT-4o, Claude 3.5 Sonnet, etc).
 - [Add URLs to the chat](https://aider.chat/docs/usage/images-urls.html) and aider will read their content.
 - [Code with your voice](https://aider.chat/docs/usage/voice.html).
-
+- Aider allows adding specified prompts via CLI arguments or Yaml configuration.
 
 ## Top tier performance
 

--- a/aider/args.py
+++ b/aider/args.py
@@ -193,6 +193,12 @@ def get_parser(default_config_files, git_root):
             " max_chat_history_tokens."
         ),
     )
+    group.add_argument(
+        "--system-prompt",
+        metavar="SYSTEM_PROMPT",
+        env_var="SYSTEM_PROMPT",
+        help="Specify additional prompts to append to the system prompt",
+    )
     # This is a duplicate of the argument in the preparser and is a no-op by this time of
     # argument parsing, but it's here so that the help is displayed as expected.
     group.add_argument(

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -232,6 +232,7 @@ class Coder:
         attribute_commit_message=False,
         aider_commit_hashes=None,
         map_mul_no_files=8,
+        system_prompt=None,
     ):
         if not fnames:
             fnames = []
@@ -371,6 +372,8 @@ class Coder:
             if self.verbose:
                 self.io.tool_output("JSON Schema:")
                 self.io.tool_output(json.dumps(self.functions, indent=4))
+
+        self.system_prompt = system_prompt
 
     def setup_lint_cmds(self, lint_cmds):
         if not lint_cmds:
@@ -751,6 +754,10 @@ class Coder:
             lazy_prompt=lazy_prompt,
             platform=platform_text,
         )
+
+        if self.system_prompt:
+            prompt += "\n" + self.system_prompt
+
         return prompt
 
     def format_messages(self):

--- a/tests/basic/test_args.py
+++ b/tests/basic/test_args.py
@@ -1,0 +1,14 @@
+import pytest
+from aider.args import get_parser
+
+def test_system_prompt_argument():
+    parser = get_parser([], None)
+    args = parser.parse_args(["--system-prompt", "Additional system prompt"])
+    assert args.system_prompt == "Additional system prompt"
+
+def test_system_prompt_yaml_config(tmp_path):
+    config_file = tmp_path / ".aider.conf.yml"
+    config_file.write_text("system_prompt: Yaml system prompt")
+    parser = get_parser([str(config_file)], None)
+    args = parser.parse_args([])
+    assert args.system_prompt == "Yaml system prompt"

--- a/tests/basic/test_base_coder.py
+++ b/tests/basic/test_base_coder.py
@@ -1,0 +1,12 @@
+import pytest
+from aider.coders.base_coder import Coder
+
+def test_fmt_system_prompt_with_cli_argument():
+    coder = Coder(system_prompt="CLI system prompt")
+    formatted_prompt = coder.fmt_system_prompt("Base system prompt")
+    assert "CLI system prompt" in formatted_prompt
+
+def test_fmt_system_prompt_with_yaml_config():
+    coder = Coder(system_prompt="Yaml system prompt")
+    formatted_prompt = coder.fmt_system_prompt("Base system prompt")
+    assert "Yaml system prompt" in formatted_prompt


### PR DESCRIPTION
Add functionality to append specified prompts to the system prompt via CLI arguments or Yaml configuration.

* Modify `aider/args.py` to add a new argument `--system-prompt` for specifying additional prompts via CLI.
* Modify `aider/coders/base_coder.py` to append additional prompts specified via CLI arguments or Yaml configuration to the system prompt.
* Update `README.md` to include information about the new `--system-prompt` argument.
* Add tests in `tests/basic/test_args.py` to ensure the new `--system-prompt` argument works correctly.
* Add tests in `tests/basic/test_base_coder.py` to ensure the `fmt_system_prompt` method correctly appends additional prompts specified via CLI arguments or Yaml configuration.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/masuidrive/aider?shareId=f04beea8-5788-44ff-81ea-75457f3d7a20).